### PR TITLE
Meilleure gestion des reprojections

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -192,7 +192,7 @@ jobs:
           sed "s#__version__#${{ github.ref_name }}#" templates/index.template.md >docs/index.md
           echo "# Versions" >docs/versions.md
           echo "" >>docs/versions.md
-          for v in `ls -t docs/versions`; do sed "s#__version__#$v#" templates/versions.template.md >>docs/versions.md; done
+          for v in `ls -t docs/versions | grep -v latest`; do sed "s#__version__#$v#" templates/versions.template.md >>docs/versions.md; done
           sed "s#__version__#${{ github.ref_name }}#" templates/latest.template.html >docs/versions/latest/index.html
           rm -r artifact
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,24 @@
 
 ## Changelog
 
+### [Added]
+
+* Level
+    * Fonction de test d'une tuile `is_in_limits` : ses indices sont ils dans les limites du niveau ?
+* Pyramid
+    * La lecture d'une tuile vérifie avant que les indices sont bien dans les limites du niveau
+    * Les exceptions levées lors du décodage de la tuile raster emettent une exception `FormatError`
+    * `get_tile_indices` accepte en entrée un système de coordonnées : c'est celui des coordonnées fournies et permet de faire une reprojection si celui ci n'est pas le même que celui des données dans la pyramide
+* Utils
+    * Meilleure gestion de reprojection par `reproject_bbox` : on détecte des systèmes identiques en entrée ou quand seul l'ordre des axes changent, pour éviter le calcul
+    * Ajout de la fonction de reprojection d'un point `reproject_point` : on détecte des systèmes identiques en entrée ou quand seul l'ordre des axes changent, pour éviter le calcul
+  
 ### [Changed]
 
-* Documentation :
-    * version latest gérée par redirection
-    * déploiement de la documentation par déclenchement manuel
-
+* Utils :
+    * `bbox_to_geometry` : on ne fournit plus de système de coordonnées, la fonction se content de créer la géométrie OGR à partir de la bbox, avec éventuellement une densification en points des bords
+* Pyramid :
+    * Renommage de fonction : `update_limits` -> `set_limits_from_bbox`. Le but est d'être plus explicite sur le fonctionnement de la fonction (on écrase les limites, on ne les met pas juste à jour par union avec la bbox fournie)
 <!--
 ### [Added]
 

--- a/src/rok4/Layer.py
+++ b/src/rok4/Layer.py
@@ -87,7 +87,7 @@ class Layer:
                 layer.__bbox = reproject_bbox(layer.__geobbox, "EPSG:4326", layer.__tms.srs, 5)
                 # On force l'emprise de la couche, on recalcule donc les tuiles limites correspondantes pour chaque niveau
                 for l in layer.__levels.values():
-                    l.update_limits(layer.__bbox)
+                    l.set_limits_from_bbox(layer.__bbox)
             else:
                 layer.__bbox = layer.__best_level.bbox
                 layer.__geobbox = reproject_bbox(layer.__bbox, layer.__tms.srs, "EPSG:4326", 5)

--- a/src/rok4/Utils.py
+++ b/src/rok4/Utils.py
@@ -31,12 +31,11 @@ def srs_to_spatialreference(srs: str) -> 'osgeo.osr.SpatialReference':
 
     return sr
 
-def bbox_to_geometry(bbox: Tuple[float, float, float, float], srs: str = None, densification: int = 0) -> 'osgeo.ogr.Geometry':  
+def bbox_to_geometry(bbox: Tuple[float, float, float, float], densification: int = 0) -> 'osgeo.ogr.Geometry':  
     """Convert bbox coordinates to OGR geometry
 
     Args:
         bbox (Tuple[float, float, float, float]): bounding box (xmin, ymin, xmax, ymax)
-        srs (str, optional): coordinates system. Defaults to None.
         densification (int, optional): Number of point to add for each side of bounding box. Defaults to 0.
 
     Raises:
@@ -73,9 +72,6 @@ def bbox_to_geometry(bbox: Tuple[float, float, float, float], srs: str = None, d
     geom = ogr.Geometry(ogr.wkbPolygon)
     geom.AddGeometry(ring)
     geom.SetCoordinateDimension(2)
-
-    if srs is not None:
-        geom.AssignSpatialReference(srs_to_spatialreference(srs))
     
     return geom
 
@@ -96,12 +92,56 @@ def reproject_bbox(bbox: Tuple[float, float, float, float], srs_src: str, srs_ds
         Tuple[float, float, float, float]: bounding box (xmin, ymin, xmax, ymax) with destination coordinates system
     """
 
-    bbox_src = bbox_to_geometry(bbox, srs_src, densification)
-    sr_geo = srs_to_spatialreference(srs_dst)
+    sr_src = srs_to_spatialreference(srs_src)
+    sr_src_inv = (sr_src.EPSGTreatsAsLatLong() or sr_src.EPSGTreatsAsNorthingEasting())
+
+    sr_dst = srs_to_spatialreference(srs_dst)
+    sr_dst_inv = (sr_dst.EPSGTreatsAsLatLong() or sr_dst.EPSGTreatsAsNorthingEasting())
+
+    if sr_src.IsSame(sr_dst) and sr_src_inv == sr_dst_inv:
+        # Les système sont vraiment les même, avec le même ordre des axes
+        return bbox
+    elif sr_src.IsSame(sr_dst) and sr_src_inv != sr_dst_inv:
+        # Les système sont les même pour OSR, mais l'ordre des axes est différent
+        return (bbox[1], bbox[0], bbox[3], bbox[2])
+
+    # Systèmes différents
+
+    bbox_src = bbox_to_geometry(bbox, densification)
+    bbox_src.AssignSpatialReference(sr_src)
 
     bbox_dst = bbox_src.Clone()
     os.environ["OGR_ENABLE_PARTIAL_REPROJECTION"] = "YES"
-    bbox_dst.TransformTo(sr_geo)
+    bbox_dst.TransformTo(sr_dst)
 
     env = bbox_dst.GetEnvelope()
     return (env[0], env[2], env[1], env[3])
+
+
+def reproject_point(point: Tuple[float, float], sr_src: 'osgeo.osr.SpatialReference', sr_dst: 'osgeo.osr.SpatialReference') -> Tuple[float, float]:
+    """Reproject a point
+
+    Args:
+        point (Tuple[float, float]): source spatial reference point
+        sr_src (osgeo.osr.SpatialReference): source spatial reference
+        sr_dst (osgeo.osr.SpatialReference): destination spatial reference
+
+    Returns:
+        Tuple[float, float]: X/Y in destination spatial reference
+    """
+
+    sr_src_inv = (sr_src.EPSGTreatsAsLatLong() or sr_src.EPSGTreatsAsNorthingEasting())
+    sr_dst_inv = (sr_dst.EPSGTreatsAsLatLong() or sr_dst.EPSGTreatsAsNorthingEasting())
+
+    if sr_src.IsSame(sr_dst) and sr_src_inv == sr_dst_inv:
+        # Les système sont vraiment les même, avec le même ordre des axes
+        return (point[0], point[1])
+    elif sr_src.IsSame(sr_dst) and sr_src_inv != sr_dst_inv:
+        # Les système sont les même pour OSR, mais l'ordre des axes est différent
+        return (point[1], point[0])
+
+    # Systèmes différents
+    ct = osr.CreateCoordinateTransformation(sr_src, sr_dst)
+    x_dst, y_dst, z_dst = ct.TransformPoint(point[0], point[1])
+
+    return (x_dst, y_dst)

--- a/tests/test_Pyramid.py
+++ b/tests/test_Pyramid.py
@@ -1,6 +1,7 @@
 from rok4.Pyramid import *
 from rok4.TileMatrixSet import TileMatrixSet
 from rok4.Storage import StorageType
+from rok4.Utils import *
 from rok4.Exceptions import *
 
 import pytest
@@ -91,6 +92,7 @@ def test_raster_ok(mocked_put_data_str, mocked_tms_class, mocked_get_data_str):
     tms_instance = MagicMock()
     tms_instance.name = "PM"
     tms_instance.srs = "EPSG:3857"
+    tms_instance.sr = sr_src = srs_to_spatialreference("EPSG:3857")
 
     tm_instance = MagicMock()
     tm_instance.id = "0"
@@ -117,7 +119,8 @@ def test_raster_ok(mocked_put_data_str, mocked_tms_class, mocked_get_data_str):
         assert clone.get_level("0") is not None
         assert clone.get_level("4") is None
         assert clone.get_infos_from_slab_path("IMAGE/12/00/00/00.tif") == (SlabType.DATA, "12", 0, 0)
-        assert clone.get_tile_indices(102458, 6548125) == ("0",0,0,128,157)
+        assert clone.get_tile_indices(102458, 6548125, srs = "EPSG:3857") == ("0",0,0,128,157)
+        assert clone.get_tile_indices(43, 2, srs = "EPSG:4326") == ("0",0,0,128,157)
 
 
         assert len(clone.get_levels()) == 1

--- a/tests/test_Utils.py
+++ b/tests/test_Utils.py
@@ -41,5 +41,22 @@ def test_reproject_bbox_ok():
     try:
         bbox = reproject_bbox((-90, -180, 90, 180), "EPSG:4326", "EPSG:3857")
         assert bbox[0] == -20037508.342789244
+        bbox = reproject_bbox((43, 3, 44, 4), "EPSG:4326", "IGNF:WGS84G")
+        assert bbox[0] == 3
+    except Exception as exc:
+        assert False, f"Bbox reprojection raises an exception: {exc}"
+
+def test_reproject_point_ok():
+    try:
+        sr_4326 = srs_to_spatialreference("EPSG:4326")
+        sr_3857 = srs_to_spatialreference("EPSG:3857")
+        sr_ignf = srs_to_spatialreference("IGNF:WGS84G")
+        x,y = reproject_point((43, 3), sr_4326, sr_3857)
+        assert (x,y) == (333958.4723798207, 5311971.846945471)
+        x,y = reproject_point((43, 3), sr_4326, sr_ignf)
+        assert (x,y) == (3, 43)
+
+        bbox = reproject_bbox((43, 3, 44, 4), "EPSG:4326", "IGNF:WGS84G")
+        assert bbox[0] == 3
     except Exception as exc:
         assert False, f"Bbox reprojection raises an exception: {exc}"


### PR DESCRIPTION
- On peut demander le pixel dans une pyramide à partir de coordonnées dans un autre système que celui de la pyramide (de son TMS)
- Lorsque les deux systèmes identique modulo l'ordre des axes, on le détecte et on on inverse simplement les coordonnées (pour la reprojection de bbox et de point)