### PR TITLE
Outillage : ajoute pyupgrade comme git hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,10 @@ repos:
         args: [--pytest-test-first]
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+      - id: pyupgrade
+        args:
+          - "--py38-plus"

--- a/src/rok4/Pyramid.py
+++ b/src/rok4/Pyramid.py
@@ -736,7 +736,7 @@ class Pyramid:
             roots = {}
             s3_cluster = self.storage_s3_cluster
 
-            with open(list_file, "r") as listin:
+            with open(list_file) as listin:
 
                 # Lecture des racines
                 for line in listin:

--- a/src/rok4/Storage.py
+++ b/src/rok4/Storage.py
@@ -806,7 +806,7 @@ def link(target_path: str, link_path: str, hard: bool = False) -> None:
 
         try:
             target_s3_client["client"].put_object(
-                Body = f"{__OBJECT_SYMLINK_SIGNATURE}{target_bucket}/{target_base_name}".encode('utf-8'),
+                Body = f"{__OBJECT_SYMLINK_SIGNATURE}{target_bucket}/{target_base_name}".encode(),
                 Bucket = link_bucket,
                 Key = link_base_name
             )
@@ -818,7 +818,7 @@ def link(target_path: str, link_path: str, hard: bool = False) -> None:
         ioctx = __get_ceph_ioctx(link_tray)
 
         try:
-            ioctx.write_full(link_base_name, f"{__OBJECT_SYMLINK_SIGNATURE}{target_path}".encode('utf-8'))
+            ioctx.write_full(link_base_name, f"{__OBJECT_SYMLINK_SIGNATURE}{target_path}".encode())
         except Exception as e:
             raise StorageError("CEPH", e)
 


### PR DESCRIPTION
**pyupgrade** est un git hook développé par l'auteur de pre-commit (et dév de pytest/flake8 par ailleurs) qui permet d'utiliser la syntaxe sur la base à une version minimale de Python.

Cela permet de mettre à jour son code "automatiquement" au regard des pratiques du langage (f-string, etc.) et souvent d'en alléger la syntaxe.

Cette PR ajoute le git hook à la config (en utilisant Python 3.8) et l'applique à la base de code.

PR liée à https://github.com/rok4/core-python/pull/36