### PR TITLE
Outillage : ajoute black comme git hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,8 @@ repos:
         args: [--pytest-test-first]
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,9 @@ doc = [
 requires = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.black]
+line-length = 100
+target-version = ['py38']
+
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
J'ai configuré la longueur de lignes sur 100 pour viser un consensus.

PR liée à https://github.com/rok4/core-python/pull/36