### PR TITLE
Outillage : ajoute la configuration pour la génération automatique des notes de version

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+ci-cd:
+  - .github/**/*
+
+dependencies:
+  - requirements.txt
+  - requirements/*.txt
+
+documentation:
+  - docs/**/*
+
+enhancement:
+  - src/**/*
+
+quality:
+  - tests/**/*
+
+tooling:
+  - .gitignore
+  - .pre-commit-config.yaml
+  - setup.cfg
+  - pyproject.toml

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci
+  categories:
+    - title: Correction de bugs 🐛
+      labels:
+        - bug
+    - title: Améliorations et nouvelles fonctionnalités 🎉
+      labels:
+        - enhancement
+        - quality
+    - title: Outillage 🔧
+      labels:
+        - ci-cd
+        - dependencies
+        - tooling
+    - title: Documentation 📖
+      labels:
+        - documentation
+    - title: Divers
+      labels:
+        - "*"

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -1,0 +1,15 @@
+name: "🏷 PR Labeler"
+on:
+  - pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
En complément de https://github.com/rok4/core-python/pull/40, cette PR permet d'automatiser la génération des notes de version :

1. _auto-labeler_ : applique une ou plusieurs étiquettes à une PR selon les fichiers modifiés
2. _auto-release_ : utilise les labels des PRs mergées depuis la dernière release (tag) pour organiser les notes de version

## Implications sur la gestion du projet

- gérer les étiquettes du projet https://github.com/rok4/core-python/labels
- appliquer systématiquement une étiquette sur les PRs

## Références

- https://docs.github.com/fr/repositories/releasing-projects-on-github/automatically-generated-release-notes
- https://github.com/actions/labeler