### PR TITLE
Outillage : précise la version cible de Python au git hook Black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,4 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
+        args: ["--target-version=py38"]


### PR DESCRIPTION
Normalement, il tient compte de la config du pyproject.toml mais on n'est jamais trop prudent :grin:.