### PR TITLE
Packaging : rend l'installation indépendante de librados

### DIFF
--- a/src/rok4/storage.py
+++ b/src/rok4/storage.py
@@ -35,13 +35,11 @@ import os
 import re
 import tempfile
 from shutil import copyfile
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Tuple, Union
 
 import boto3
 import botocore.exceptions
 import requests
-from typing import Dict, List, Tuple, Union
-from shutil import copyfile
 from osgeo import gdal
 
 # conditional import

--- a/src/rok4/storage.py
+++ b/src/rok4/storage.py
@@ -62,6 +62,7 @@ gdal.UseExceptions()
 
 __CEPH_CLIENT = None
 __CEPH_IOCTXS = {}
+__OBJECT_SYMLINK_SIGNATURE = "SYMLINK#"
 __S3_CLIENTS = {}
 __S3_DEFAULT_CLIENT = None
 

--- a/src/rok4/storage.py
+++ b/src/rok4/storage.py
@@ -51,8 +51,7 @@ except ImportError:
     CEPH_RADOS_AVAILABLE: bool = False
     rados = None
 
-gdal.UseExceptions()
-
+# package
 from rok4.enums import StorageType
 from rok4.exceptions import MissingEnvironmentError, StorageError
 
@@ -60,6 +59,9 @@ from rok4.exceptions import MissingEnvironmentError, StorageError
 
 # Enable GDAL/OGR exceptions
 gdal.UseExceptions()
+
+__CEPH_CLIENT = None
+__CEPH_IOCTXS = {}
 __S3_CLIENTS = {}
 __S3_DEFAULT_CLIENT = None
 
@@ -142,10 +144,6 @@ def disconnect_s3_clients() -> None:
     global __S3_CLIENTS, __S3_DEFAULT_CLIENT
     __S3_CLIENTS = {}
     __S3_DEFAULT_CLIENT = None
-
-
-__CEPH_CLIENT = None
-__CEPH_IOCTXS = {}
 
 
 def __get_ceph_ioctx(pool: str) -> "rados.Ioctx":

--- a/src/rok4/storage.py
+++ b/src/rok4/storage.py
@@ -195,9 +195,6 @@ def disconnect_ceph_clients() -> None:
     __CEPH_IOCTXS = {}
 
 
-__OBJECT_SYMLINK_SIGNATURE = "SYMLINK#"
-
-
 def get_infos_from_path(path: str) -> Tuple[StorageType, str, str, str]:
     """Extract storage type, the unprefixed path, the container and the basename from path (Default: FILE storage)
 

--- a/src/rok4/storage.py
+++ b/src/rok4/storage.py
@@ -30,24 +30,36 @@ Example: work with 2 S3 clusters:
 To precise the cluster to use, bucket name should be bucket_name@s3.storage.fr or bucket_name@s4.storage.fr. If no host is defined (no @) in the bucket name, first S3 cluster is used
 """
 
-# -- IMPORTS --
-
-# standard library
 import hashlib
 import os
 import re
 import tempfile
 from shutil import copyfile
-from typing import Dict, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
-# 3rd party
 import boto3
 import botocore.exceptions
+import tempfile
+import re
+import os
 import rados
+import hashlib
 import requests
+from typing import Dict, List, Tuple, Union
+from shutil import copyfile
 from osgeo import gdal
 
-# package
+# conditional import
+try:
+    import rados
+
+    CEPH_RADOS_AVAILABLE: bool = True
+except ImportError:
+    CEPH_RADOS_AVAILABLE: bool = False
+    rados = None
+
+gdal.UseExceptions()
+
 from rok4.enums import StorageType
 from rok4.exceptions import MissingEnvironmentError, StorageError
 

--- a/src/rok4/storage.py
+++ b/src/rok4/storage.py
@@ -39,11 +39,6 @@ from typing import Dict, List, Tuple, Union
 
 import boto3
 import botocore.exceptions
-import tempfile
-import re
-import os
-import rados
-import hashlib
 import requests
 from typing import Dict, List, Tuple, Union
 from shutil import copyfile


### PR DESCRIPTION
- [x] ne plante pas si le projet est installé alors que librados n'est pas disponible
- [ ] gérer le cas au niveau du setup - a priori pas besoin
- [ ] modulariser les stockages pour en implémenter d'autres de façon cohérente - remis à plus tard

Désolé @Dolite, j'ai pas le temps de pousser le reste. Faut que je remette mon dpéôt local au propre après les autres PRs.