### PR TITLE
Ajoute requests comme dépendance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,10 @@ classifiers = [
 
 dependencies = [
   "boto3 >= 1.26.54",
-  "pillow >= 9.4.0",
+  "mapbox-vector-tile >= 2.0.1",
   "numpy >= 1.24.2",
-  "mapbox-vector-tile >= 2.0.1"
+  "pillow >= 9.4.0",
+  "requests >= 2.31.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "mapbox-vector-tile >= 2.0.1",
   "numpy >= 1.24.2",
   "pillow >= 9.4.0",
-  "requests >= 2.31.0"
+  "requests >= 2.30.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
requests est utilisé dans storage (https://github.com/Guts/rok4-core-python/blob/31e3fce7e50d4851c497cf1f1ac96771ed4c3483/src/rok4/storage.py#L40) mais n'est pas listé comme dépendance tierce.

Cette PR corrige le tir.

@Dolite cette PR est importante.