### PR TITLE
Outillage : ajoute la configuration pour pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,6 @@ repos:
       - id: black
         args: ["--target-version=py38"]
 
-
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -40,3 +39,9 @@ repos:
       - id: pyupgrade
         args:
           - "--py38-plus"
+
+ci:
+  autofix_commit_msg: "[pre-commit.ci] Corrections automatiques appliquées par les git hooks."
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] Mise à jour des git hooks."
+  autoupdate_schedule: quarterly


### PR DESCRIPTION
Développée par l'auteur (et contributeurs associés) de pre-commit, https://pre-commit.ci/ permet d'automatiser 2 tâches récurrentes autour de l'utilisation des git hooks :+1: 

- MAJ des hooks configurés
- exécution automatique sur les PR

Cette PR ajoute la section de configuration.

Il faut que l'un des admins de ce dépôt aille activer/autoriser le dépôt à https://results.pre-commit.ci/.