### PR TITLE
Outillage : ajoute ruff comme dépendance de dév et git hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.0.281"
+    hooks:
+      - id: ruff
+        args: ["--fix-only", "--target-version=py38"]
+
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ doc = [
 dev = [
   "black",
   "isort >= 5.12.0",
-  "pre-commit >3,<4"
+  "pre-commit >3,<4",
+  "ruff >= 0.0.281"
 ]
 
 test = [
@@ -67,6 +68,15 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 100
 target-version = ['py38']
+
+[tool.ruff]
+line-length = 100
+src = ["src"]
+target-version = "py38"
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
ruff est le dernier venu dans l'écosystème Python des linters etc. Développé en rust, il ambitionne de les remplacer tous (mouais bon ok...) et d'aller beaucoup plus vite (ça c'est vrai).

Un aspect très intéressant est qu'il implémente beaucoup d'autofix.

https://beta.ruff.rs/docs/