### PR TITLE
Correction de la lecture d'une tuile d'une pyramide PNG 1 canal

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(b(?P<beta>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}b{beta}
 	{major}.{minor}.{patch}
 

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -27,7 +27,7 @@ jobs:
           name: Release ${{ github.ref_name }}
           generateReleaseNotes: true
           draft: false
-          prerelease: contains(${{ github.ref_name }},'b')
+          prerelease: ${{ contains(github.ref_name ,'b') }}
 
   build_and_test:
 
@@ -80,7 +80,7 @@ jobs:
           coverage report -m
 
       - name: Build unit tests report
-        if: "matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.8'"
+        if: "! contains(github.ref_name,'b') && matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.8'"
         run: |
           source .venv/bin/activate
           coverage html -d dist/tests/
@@ -93,7 +93,7 @@ jobs:
           python3 -m build
 
       - name: Build documentation
-        if: "matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.8'"
+        if: "! contains(github.ref_name,'b') && matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.8'"
         run: |
           source .venv/bin/activate
           pip install -e .[doc]
@@ -112,7 +112,7 @@ jobs:
   publish_artefacts:
     name: Add built artefacts to release and PyPI
     needs: [create_release, build_and_test]
-    if: "always()&&(needs.create_release.outputs.job_status=='success')&&(needs.build_and_test.outputs.job_status=='success')"
+    if: "always() && needs.create_release.outputs.job_status == 'success' && needs.build_and_test.outputs.job_status == 'success'"
     runs-on: ubuntu-latest
 
     steps:
@@ -158,7 +158,7 @@ jobs:
   commit_documentation:
     name: Add documentation and unit tests results into gh-pages branch
     needs: build_and_test
-    if: "!(contains(${{ github.ref_name }},'b'))&&(needs.create_release.outputs.job_status=='success')&&(needs.build_and_test.outputs.job_status=='success')"
+    if: "always() && ! contains(github.ref_name,'b') && needs.create_release.outputs.job_status == 'success' && needs.build_and_test.outputs.job_status == 'success'"
     runs-on: ubuntu-latest
 
     steps:
@@ -208,7 +208,7 @@ jobs:
   delete_version:
     name: Remove release and tag if error occured
     needs: build_and_test
-    if: "always()&&(needs.create_release.outputs.job_status=='success')&&(needs.build_and_test.outputs.job_status!='success')"
+    if: "always() && needs.create_release.outputs.job_status == 'success' && needs.build_and_test.outputs.job_status != 'success'"
     runs-on: ubuntu-latest
 
     steps:

--- a/src/rok4/pyramid.py
+++ b/src/rok4/pyramid.py
@@ -1189,6 +1189,11 @@ class Pyramid:
                 raise FormatError("JPEG", "binary tile", e)
 
             data = numpy.asarray(img)
+            data.shape = (
+                level_object.tile_matrix.tile_size[0],
+                level_object.tile_matrix.tile_size[1],
+                self.__raster_specifications["channels"],
+            )
 
         elif self.__format == "TIFF_RAW_UINT8":
             data = numpy.frombuffer(binary_tile, dtype=numpy.dtype("uint8"))
@@ -1205,6 +1210,11 @@ class Pyramid:
                 raise FormatError("PNG", "binary tile", e)
 
             data = numpy.asarray(img)
+            data.shape = (
+                level_object.tile_matrix.tile_size[0],
+                level_object.tile_matrix.tile_size[1],
+                self.__raster_specifications["channels"],
+            )
 
         elif self.__format == "TIFF_ZIP_UINT8":
             try:

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -2,8 +2,6 @@ import os
 from unittest import mock
 from unittest.mock import *
 
-import pytest
-
 from rok4.enums import PyramidType
 from rok4.exceptions import *
 from rok4.layer import Layer

--- a/tests/test_pyramid.py
+++ b/tests/test_pyramid.py
@@ -7,14 +7,13 @@ import pytest
 from rok4.enums import SlabType, StorageType
 from rok4.exceptions import *
 from rok4.pyramid import *
-from rok4.tile_matrix_set import TileMatrixSet
 from rok4.utils import *
 
 
 @mock.patch("rok4.pyramid.get_data_str", side_effect=StorageError("FILE", "Not found"))
 def test_wrong_file(mocked_get_data_str):
     with pytest.raises(StorageError):
-        pyramid = Pyramid.from_descriptor("file:///pyramid.json")
+        Pyramid.from_descriptor("file:///pyramid.json")
 
 
 @mock.patch(
@@ -23,7 +22,7 @@ def test_wrong_file(mocked_get_data_str):
 )
 def test_bad_json(mocked_get_data_str):
     with pytest.raises(FormatError) as exc:
-        pyramid = Pyramid.from_descriptor("file:///pyramid.json")
+        Pyramid.from_descriptor("file:///pyramid.json")
 
     assert (
         str(exc.value)
@@ -35,7 +34,7 @@ def test_bad_json(mocked_get_data_str):
 @mock.patch("rok4.pyramid.get_data_str", return_value='{"format": "TIFF_PBF_MVT","levels":[]}')
 def test_missing_tms(mocked_get_data_str):
     with pytest.raises(MissingAttributeError) as exc:
-        pyramid = Pyramid.from_descriptor("file:///pyramid.json")
+        Pyramid.from_descriptor("file:///pyramid.json")
 
     assert str(exc.value) == "Missing attribute 'tile_matrix_set' in 'file:///pyramid.json'"
     mocked_get_data_str.assert_called_once_with("file:///pyramid.json")
@@ -49,7 +48,7 @@ def test_missing_tms(mocked_get_data_str):
 @mock.patch("rok4.pyramid.TileMatrixSet", side_effect=StorageError("FILE", "TMS not found"))
 def test_wrong_tms(mocked_tms_constructor, mocked_get_data_str):
     with pytest.raises(StorageError) as exc:
-        pyramid = Pyramid.from_descriptor("file:///pyramid.json")
+        Pyramid.from_descriptor("file:///pyramid.json")
 
     assert str(exc.value) == "Issue occured using a FILE storage : TMS not found"
     mocked_tms_constructor.assert_called_once_with("PM")
@@ -64,7 +63,7 @@ def test_wrong_tms(mocked_tms_constructor, mocked_get_data_str):
 @mock.patch("rok4.pyramid.TileMatrixSet")
 def test_raster_missing_raster_specifications(mocked_tms_class, mocked_get_data_str):
     with pytest.raises(MissingAttributeError) as exc:
-        pyramid = Pyramid.from_descriptor("file:///pyramid.json")
+        Pyramid.from_descriptor("file:///pyramid.json")
 
     assert str(exc.value) == "Missing attribute 'raster_specifications' in 'file:///pyramid.json'"
     mocked_get_data_str.assert_called_once_with("file:///pyramid.json")
@@ -83,7 +82,7 @@ def test_wrong_level(mocked_tms_class, mocked_get_data_str):
     mocked_tms_class.return_value = tms_instance
 
     with pytest.raises(Exception) as exc:
-        pyramid = Pyramid.from_descriptor("file:///pyramid.json")
+        Pyramid.from_descriptor("file:///pyramid.json")
 
     mocked_tms_class.assert_called_once_with("PM")
     mocked_get_data_str.assert_called_once_with("file:///pyramid.json")
@@ -102,7 +101,7 @@ def test_wrong_level(mocked_tms_class, mocked_get_data_str):
 @mock.patch("rok4.pyramid.TileMatrixSet", autospec=True)
 def test_vector_missing_tables(mocked_tms_class, mocked_get_data_str):
     with pytest.raises(MissingAttributeError) as exc:
-        pyramid = Pyramid.from_descriptor("file:///pyramid.json")
+        Pyramid.from_descriptor("file:///pyramid.json")
 
     assert str(exc.value) == "Missing attribute levels[].'tables' in 'file:///pyramid.json'"
     mocked_get_data_str.assert_called_once_with("file:///pyramid.json")
@@ -119,7 +118,7 @@ def test_raster_ok(mocked_put_data_str, mocked_tms_class, mocked_get_data_str):
     tms_instance = MagicMock()
     tms_instance.name = "PM"
     tms_instance.srs = "EPSG:3857"
-    tms_instance.sr = sr_src = srs_to_spatialreference("EPSG:3857")
+    tms_instance.sr = srs_to_spatialreference("EPSG:3857")
 
     tm_instance = MagicMock()
     tm_instance.id = "0"
@@ -191,7 +190,7 @@ def test_vector_ok(mocked_tms_class, mocked_get_data_str):
     except Exception as exc:
         assert False, f"Pyramid creation raises an exception: {exc}"
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception):
         pyramid.get_tile_data_raster("12", 5, 6)
 
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -10,7 +10,7 @@ import json
 import math
 import random
 from unittest import TestCase, mock
-from unittest.mock import MagicMock, Mock, call, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open
 
 import pytest
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,7 +4,6 @@ from unittest.mock import *
 
 import botocore.exceptions
 import pytest
-from rados import ObjectNotFound
 
 from rok4.enums import StorageType
 from rok4.exceptions import *
@@ -55,13 +54,13 @@ def test_get_path_from_infos():
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_s3_missing_env():
     with pytest.raises(MissingEnvironmentError):
-        data = get_data_str("s3://bucket/path/to/object")
+        get_data_str("s3://bucket/path/to/object")
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_ceph_missing_env():
     with pytest.raises(MissingEnvironmentError):
-        data = get_data_str("ceph://bucket/path/to/object")
+        get_data_str("ceph://bucket/path/to/object")
 
 
 @mock.patch.dict(
@@ -71,7 +70,7 @@ def test_ceph_missing_env():
 )
 def test_s3_invalid_envs():
     with pytest.raises(StorageError):
-        data = get_data_str("s3://bucket/path/to/object")
+        get_data_str("s3://bucket/path/to/object")
 
 
 @mock.patch.dict(
@@ -79,17 +78,17 @@ def test_s3_invalid_envs():
 )
 @mock.patch("rok4.storage.boto3.client")
 def test_s3_invalid_endpoint(mocked_s3_client):
-    s3_instance = MagicMock()
+    MagicMock()
     mocked_s3_client.side_effect = Exception("Invalid URL")
     with pytest.raises(StorageError):
-        data = get_data_str("s3://bucket/path/to/object")
+        get_data_str("s3://bucket/path/to/object")
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
 @mock.patch("builtins.open", side_effect=FileNotFoundError("not_found"))
 def test_file_read_error(mock_file):
     with pytest.raises(FileNotFoundError):
-        data = get_data_str("file:///path/to/file.ext")
+        get_data_str("file:///path/to/file.ext")
 
     mock_file.assert_called_with("/path/to/file.ext", "rb")
 
@@ -117,7 +116,7 @@ def test_s3_read_nok(mocked_s3_client):
     s3_instance.get_object.side_effect = Exception("Bucket or object not found")
     mocked_s3_client.return_value = s3_instance
     with pytest.raises(StorageError):
-        data = get_data_str("s3://bucket/path/to/object")
+        get_data_str("s3://bucket/path/to/object")
 
 
 @mock.patch.dict(
@@ -171,7 +170,7 @@ def test_http_read_error(mock_http):
         requests_instance.content = "NULL"
         requests_instance.status_code = 404
         mock_http.return_value = requests_instance
-        data = get_data_str("http://path/to/file.ext")
+        get_data_str("http://path/to/file.ext")
 
     mock_http.assert_called_with("http://path/to/file.ext", stream=True)
 
@@ -179,7 +178,7 @@ def test_http_read_error(mock_http):
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_http_read_range_error():
     with pytest.raises(NotImplementedError):
-        data = get_data_binary("http://path/to/file.ext", (0, 100))
+        get_data_binary("http://path/to/file.ext", (0, 100))
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
@@ -925,7 +924,7 @@ def test_size_path_file_ok():
 
 def test_size_file_nok():
     with pytest.raises(StorageError):
-        size = size_path("file://tests/fixtures/TIFF_PBF_M")
+        size_path("file://tests/fixtures/TIFF_PBF_M")
 
 
 @mock.patch.dict(
@@ -935,7 +934,7 @@ def test_size_file_nok():
 )
 def test_size_path_ceph_nok():
     with pytest.raises(NotImplementedError):
-        size = size_path("ceph://pool/path")
+        size_path("ceph://pool/path")
 
 
 @mock.patch.dict(

--- a/tests/test_tile_matrix_set.py
+++ b/tests/test_tile_matrix_set.py
@@ -11,14 +11,14 @@ from rok4.tile_matrix_set import TileMatrixSet
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_missing_env():
     with pytest.raises(MissingEnvironmentError):
-        tms = TileMatrixSet("tms")
+        TileMatrixSet("tms")
 
 
 @mock.patch.dict(os.environ, {"ROK4_TMS_DIRECTORY": "file:///path/to"}, clear=True)
 @mock.patch("rok4.tile_matrix_set.get_data_str", side_effect=StorageError("FILE", "Not found"))
 def test_wrong_file(mocked_get_data_str):
     with pytest.raises(StorageError):
-        tms = TileMatrixSet("tms")
+        TileMatrixSet("tms")
 
 
 @mock.patch.dict(os.environ, {"ROK4_TMS_DIRECTORY": "file:///path/to"}, clear=True)
@@ -27,8 +27,8 @@ def test_wrong_file(mocked_get_data_str):
     return_value='"crs":"EPSG:3857","orderedAxes":["X","Y"],"id":"PM"}',
 )
 def test_bad_json(mocked_get_data_str):
-    with pytest.raises(FormatError) as exc:
-        tms = TileMatrixSet("tms")
+    with pytest.raises(FormatError):
+        TileMatrixSet("tms")
     mocked_get_data_str.assert_called_once_with("file:///path/to/tms.json")
 
 
@@ -39,7 +39,7 @@ def test_bad_json(mocked_get_data_str):
 )
 def test_missing_id(mocked_get_data_str):
     with pytest.raises(MissingAttributeError) as exc:
-        tms = TileMatrixSet("tms")
+        TileMatrixSet("tms")
     assert str(exc.value) == "Missing attribute 'id' in 'file:///path/to/tms.json'"
     mocked_get_data_str.assert_called_once_with("file:///path/to/tms.json")
 
@@ -51,7 +51,7 @@ def test_missing_id(mocked_get_data_str):
 )
 def test_missing_crs(mocked_get_data_str):
     with pytest.raises(MissingAttributeError) as exc:
-        tms = TileMatrixSet("tms")
+        TileMatrixSet("tms")
     assert str(exc.value) == "Missing attribute 'crs' in 'file:///path/to/tms.json'"
     mocked_get_data_str.assert_called_once_with("file:///path/to/tms.json")
 
@@ -63,7 +63,7 @@ def test_missing_crs(mocked_get_data_str):
 )
 def test_wrong_crs(mocked_get_data_str):
     with pytest.raises(Exception) as exc:
-        tms = TileMatrixSet("tms")
+        TileMatrixSet("tms")
     assert (
         str(exc.value)
         == "Wrong attribute 'crs' ('epsg:123456') in 'file:///path/to/tms.json', not recognize by OSR. Trace : PROJ: proj_create_from_database: crs not found"
@@ -78,7 +78,7 @@ def test_wrong_crs(mocked_get_data_str):
 )
 def test_wrong_axes_order(mocked_get_data_str):
     with pytest.raises(Exception) as exc:
-        tms = TileMatrixSet("tms")
+        TileMatrixSet("tms")
     assert (
         str(exc.value)
         == "TMS 'file:///path/to/tms.json' own invalid axes order : only X/Y or Lon/Lat are handled"
@@ -93,7 +93,7 @@ def test_wrong_axes_order(mocked_get_data_str):
 )
 def test_missing_levels(mocked_get_data_str):
     with pytest.raises(MissingAttributeError) as exc:
-        tms = TileMatrixSet("tms")
+        TileMatrixSet("tms")
     assert str(exc.value) == "Missing attribute 'tileMatrices' in 'file:///path/to/tms.json'"
     mocked_get_data_str.assert_called_once_with("file:///path/to/tms.json")
 
@@ -105,7 +105,7 @@ def test_missing_levels(mocked_get_data_str):
 )
 def test_no_levels(mocked_get_data_str):
     with pytest.raises(Exception) as exc:
-        tms = TileMatrixSet("tms")
+        TileMatrixSet("tms")
     assert str(exc.value) == "TMS 'file:///path/to/tms.json' has no level"
     mocked_get_data_str.assert_called_once_with("file:///path/to/tms.json")
 
@@ -117,7 +117,7 @@ def test_no_levels(mocked_get_data_str):
 )
 def test_wrong_level(mocked_get_data_str):
     with pytest.raises(MissingAttributeError) as exc:
-        tms = TileMatrixSet("tms")
+        TileMatrixSet("tms")
     assert str(exc.value) == "Missing attribute tileMatrices[].'id' in 'file:///path/to/tms.json'"
     mocked_get_data_str.assert_called_once_with("file:///path/to/tms.json")
 
@@ -129,7 +129,7 @@ def test_wrong_level(mocked_get_data_str):
 )
 def test_wrong_level_id(mocked_get_data_str):
     with pytest.raises(Exception) as exc:
-        tms = TileMatrixSet("tms")
+        TileMatrixSet("tms")
 
     assert (
         str(exc.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import math
-import os
 import random
 from unittest import mock
 from unittest.mock import *
@@ -13,28 +12,28 @@ from rok4.utils import *
 
 def test_srs_to_spatialreference_ignf_ok():
     try:
-        sr = srs_to_spatialreference("IGNF:LAMB93")
-        sr = srs_to_spatialreference("ignf:lamb93")
+        srs_to_spatialreference("IGNF:LAMB93")
+        srs_to_spatialreference("ignf:lamb93")
     except Exception as exc:
         assert False, f"SpatialReference creation raises an exception: {exc}"
 
 
 def test_srs_to_spatialreference_epsg_ok():
     try:
-        sr = srs_to_spatialreference("EPSG:3857")
-        sr = srs_to_spatialreference("epsg:3857")
+        srs_to_spatialreference("EPSG:3857")
+        srs_to_spatialreference("epsg:3857")
     except Exception as exc:
         assert False, f"SpatialReference creation raises an exception: {exc}"
 
 
 def test_srs_to_spatialreference_ignf_nok():
     with pytest.raises(Exception):
-        sr = srs_to_spatialreference("IGNF:TOTO")
+        srs_to_spatialreference("IGNF:TOTO")
 
 
 def test_srs_to_spatialreference_epsg_nok():
     with pytest.raises(Exception):
-        sr = srs_to_spatialreference("EPSG:123456")
+        srs_to_spatialreference("EPSG:123456")
 
 
 def test_bbox_to_geometry_ok():

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -13,25 +13,25 @@ from rok4.vector import *
 def test_missing_env():
     disconnect_ceph_clients()
     with pytest.raises(MissingEnvironmentError):
-        vector = Vector.from_file("ceph:///ign_std/vector.shp")
+        Vector.from_file("ceph:///ign_std/vector.shp")
 
 
 @mock.patch("rok4.vector.copy", side_effect=StorageError("CEPH", "Not found"))
 def test_wrong_file(mocked_copy):
     with pytest.raises(StorageError):
-        vector = Vector.from_file("ceph:///vector.geojson")
+        Vector.from_file("ceph:///vector.geojson")
 
 
 def test_wrong_format():
     with pytest.raises(Exception) as exc:
-        vector = Vector.from_file("ceph:///vector.tif")
+        Vector.from_file("ceph:///vector.tif")
     assert str(exc.value) == "This format of file cannot be loaded"
 
 
 @mock.patch("rok4.vector.ogr.Open", return_value="not a shape")
 def test_wrong_content(mocked_copy):
     with pytest.raises(Exception) as exc:
-        vector = Vector.from_file("file:///vector.shp")
+        Vector.from_file("file:///vector.shp")
     assert str(exc.value) == "The content of file:///vector.shp cannot be read"
 
 
@@ -39,7 +39,7 @@ def test_wrong_content(mocked_copy):
 @mock.patch("rok4.vector.ogr.Open", return_value="not a shape")
 def test_wrong_content_ceph(mocked_open, mocked_copy):
     with pytest.raises(Exception) as exc:
-        vector = Vector.from_file("file:///vector.shp")
+        Vector.from_file("file:///vector.shp")
     assert str(exc.value) == "The content of file:///vector.shp cannot be read"
 
 


### PR DESCRIPTION
### [Fixed]

* Pyramid : quand on lit une tuile dans une pyramide PNG 1 canal, on retourne bien aussi un numpy.array à 3 dimensions (la dernière dimension sera bien un array à un élément)
