### PR TITLE
MAJ la version minimale de pillow pour intégrer la correction de la faille libwebp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "boto3 >= 1.26.54",
   "mapbox-vector-tile >= 2.0.1",
   "numpy >= 1.24.2",
-  "pillow >= 9.4.0",
+  "pillow >= 10.0.1",
   "requests >= 2.30.0"
 ]
 


### PR DESCRIPTION
Références :

- https://cert.ssi.gouv.fr/actualite/CERTFR-2023-ACT-042/
- https://github.com/python-pillow/Pillow/releases/tag/10.0.1
- https://github.com/python-pillow/Pillow/pull/7395

Ticket lié : https://github.com/rok4/core-python/issues/68