### PR TITLE
Configurabilité du cache de lecture

### DIFF
--- a/src/rok4/storage.py
+++ b/src/rok4/storage.py
@@ -96,6 +96,7 @@ except ValueError:
 except KeyError:
     pass
 
+
 def __get_ttl_hash():
     """Return the time string rounded according to time-to-live value"""
     if __LRU_TTL == 0:


### PR DESCRIPTION
### [Added]

* `storage` : le cache de lecture est configurable en taille (avec ROK4_READING_LRU_CACHE_SIZE) et en temps de rétention (avec ROK4_READING_LRU_CACHE_TTL)