### PR TITLE
Correction de la détection d'objet absent en S3

### DIFF
--- a/src/rok4/storage.py
+++ b/src/rok4/storage.py
@@ -366,7 +366,7 @@ def __get_cached_data_binary(path: str, ttl_hash: int, range: Tuple[int, int] = 
                 )
 
         except botocore.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "404":
+            if e.response["Error"]["Code"] == "NoSuchKey":
                 raise FileNotFoundError(f"{storage_type.value}{path}")
             else:
                 raise StorageError("S3", e)
@@ -443,6 +443,9 @@ def get_data_binary(path: str, range: Tuple[int, int] = None) -> str:
     Returns:
         str: Data binary content
     """
+    print("########################################")
+    print(f"get_data_binary {path}")
+    print("########################################")
     return __get_cached_data_binary(path, __get_ttl_hash(), range)
 
 
@@ -573,7 +576,7 @@ def exists(path: str) -> bool:
             s3_client["client"].head_object(Bucket=bucket_name, Key=base_name)
             return True
         except botocore.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "404":
+            if e.response["Error"]["Code"] == "NoSuchKey":
                 return False
             else:
                 raise StorageError("S3", e)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -809,7 +809,7 @@ def test_exists_s3_ok(mocked_s3_client):
         assert False, f"S3 exists raises an exception: {exc}"
 
     s3_instance.head_object.side_effect = botocore.exceptions.ClientError(
-        operation_name="InvalidKeyPair.Duplicate", error_response={"Error": {"Code": "404"}}
+        operation_name="InvalidKeyPair.Duplicate", error_response={"Error": {"Code": "NoSuchKey"}}
     )
     try:
         assert not exists("s3://bucket/object.ext")


### PR DESCRIPTION
### [Fixed]

- `Storage` : dans le cas d'une lecture ou d'un test existence sur un objet S3 absent, le code dans la réponse n'est pas 404 mais NoSuchKey